### PR TITLE
Remove unused universities.js (leftover from faststream copy and paste?)

### DIFF
--- a/app/views/questionnaire/secondpage.scala.html
+++ b/app/views/questionnaire/secondpage.scala.html
@@ -39,4 +39,3 @@
 }
 
 <script src='@routes.Assets.versioned("js/vendor/jquery-ui-1.10.4.custom.min.js")' type="text/javascript"></script>
-<script src='@routes.Assets.versioned("js/universities.js")' type="text/javascript"></script>


### PR DESCRIPTION
Noticed some 404s in production, clients are trying to load this old javascript file. It doesn't exist, and doesn't seem applicable to fasttrack