### PR TITLE
removed CSRF bypass because no allowlist header present

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -36,10 +36,6 @@ session.timeoutSeconds=1800
 # Restore older play 2.3 CSRF behaviours
 play.filters.csrf {
   header {
-    bypassHeaders {
-      X-Requested-With = "*"
-      Csrf-Token = "nocheck"
-    }
     protectHeaders = null
   }
   bypassCorsTrustedOrigins = false


### PR DESCRIPTION
The CSRF bypass header is being used without an allowlist. Have removed it in this commit to close this vulnerability.
https://jira.tools.tax.service.gov.uk/browse/PSEC-1051